### PR TITLE
fix: add micromark parser to markdownlint config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
             "@silvermine/eslint-config": "3.1.0-beta.0",
             "@silvermine/standardization": "2.2.3",
             "chai": "4.3.7",
-            "markdownlint": "0.29.0",
+            "markdownlint": "0.36.1",
             "mocha": "10.2.0"
          }
       },
@@ -4067,16 +4067,19 @@
          }
       },
       "node_modules/markdownlint": {
-         "version": "0.29.0",
-         "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.29.0.tgz",
-         "integrity": "sha512-ASAzqpODstu/Qsk0xW5BPgWnK/qjpBQ4e7IpsSvvFXcfYIjanLTdwFRJK1SIEEh0fGSMKXcJf/qhaZYHyME0wA==",
+         "version": "0.36.1",
+         "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.36.1.tgz",
+         "integrity": "sha512-s73fU2CQN7WCgjhaQUQ8wYESQNzGRNOKDd+3xgVqu8kuTEhmwepd/mxOv1LR2oV046ONrTLBFsM7IoKWNvmy5g==",
          "dev": true,
          "dependencies": {
-            "markdown-it": "13.0.1",
-            "markdownlint-micromark": "0.1.5"
+            "markdown-it": "14.1.0",
+            "markdownlint-micromark": "0.1.12"
          },
          "engines": {
-            "node": ">=16"
+            "node": ">=18"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/DavidAnson"
          }
       },
       "node_modules/markdownlint-cli2": {
@@ -4203,14 +4206,73 @@
             "node": ">=14.18.0"
          }
       },
-      "node_modules/markdownlint/node_modules/markdownlint-micromark": {
-         "version": "0.1.5",
-         "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.5.tgz",
-         "integrity": "sha512-HvofNU4QCvfUCWnocQP1IAWaqop5wpWrB0mKB6SSh0fcpV0PdmQNS6tdUuFew1utpYlUvYYzz84oDkrD76GB9A==",
+      "node_modules/markdownlint/node_modules/argparse": {
+         "version": "2.0.1",
+         "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+         "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+         "dev": true
+      },
+      "node_modules/markdownlint/node_modules/entities": {
+         "version": "4.5.0",
+         "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+         "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
          "dev": true,
          "engines": {
-            "node": ">=16"
+            "node": ">=0.12"
+         },
+         "funding": {
+            "url": "https://github.com/fb55/entities?sponsor=1"
          }
+      },
+      "node_modules/markdownlint/node_modules/linkify-it": {
+         "version": "5.0.0",
+         "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+         "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+         "dev": true,
+         "dependencies": {
+            "uc.micro": "^2.0.0"
+         }
+      },
+      "node_modules/markdownlint/node_modules/markdown-it": {
+         "version": "14.1.0",
+         "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+         "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+         "dev": true,
+         "dependencies": {
+            "argparse": "^2.0.1",
+            "entities": "^4.4.0",
+            "linkify-it": "^5.0.0",
+            "mdurl": "^2.0.0",
+            "punycode.js": "^2.3.1",
+            "uc.micro": "^2.1.0"
+         },
+         "bin": {
+            "markdown-it": "bin/markdown-it.mjs"
+         }
+      },
+      "node_modules/markdownlint/node_modules/markdownlint-micromark": {
+         "version": "0.1.12",
+         "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.12.tgz",
+         "integrity": "sha512-RlB6EwMGgc0sxcIhOQ2+aq7Zw1V2fBnzbXKGgYK/mVWdT7cz34fteKSwfYeo4rL6+L/q2tyC9QtD/PgZbkdyJQ==",
+         "dev": true,
+         "engines": {
+            "node": ">=18"
+         },
+         "funding": {
+            "url": "https://github.com/sponsors/DavidAnson"
+         }
+      },
+      "node_modules/markdownlint/node_modules/mdurl": {
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+         "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+         "dev": true
+      },
+      "node_modules/markdownlint/node_modules/uc.micro": {
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+         "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+         "dev": true
       },
       "node_modules/mathml-tag-names": {
          "version": "2.1.3",
@@ -5141,6 +5203,15 @@
          "version": "2.1.1",
          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+         "dev": true,
+         "engines": {
+            "node": ">=6"
+         }
+      },
+      "node_modules/punycode.js": {
+         "version": "2.3.1",
+         "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+         "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
          "dev": true,
          "engines": {
             "node": ">=6"
@@ -10079,19 +10150,66 @@
          }
       },
       "markdownlint": {
-         "version": "0.29.0",
-         "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.29.0.tgz",
-         "integrity": "sha512-ASAzqpODstu/Qsk0xW5BPgWnK/qjpBQ4e7IpsSvvFXcfYIjanLTdwFRJK1SIEEh0fGSMKXcJf/qhaZYHyME0wA==",
+         "version": "0.36.1",
+         "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.36.1.tgz",
+         "integrity": "sha512-s73fU2CQN7WCgjhaQUQ8wYESQNzGRNOKDd+3xgVqu8kuTEhmwepd/mxOv1LR2oV046ONrTLBFsM7IoKWNvmy5g==",
          "dev": true,
          "requires": {
-            "markdown-it": "13.0.1",
-            "markdownlint-micromark": "0.1.5"
+            "markdown-it": "14.1.0",
+            "markdownlint-micromark": "0.1.12"
          },
          "dependencies": {
+            "argparse": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+               "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+               "dev": true
+            },
+            "entities": {
+               "version": "4.5.0",
+               "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+               "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+               "dev": true
+            },
+            "linkify-it": {
+               "version": "5.0.0",
+               "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+               "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+               "dev": true,
+               "requires": {
+                  "uc.micro": "^2.0.0"
+               }
+            },
+            "markdown-it": {
+               "version": "14.1.0",
+               "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+               "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+               "dev": true,
+               "requires": {
+                  "argparse": "^2.0.1",
+                  "entities": "^4.4.0",
+                  "linkify-it": "^5.0.0",
+                  "mdurl": "^2.0.0",
+                  "punycode.js": "^2.3.1",
+                  "uc.micro": "^2.1.0"
+               }
+            },
             "markdownlint-micromark": {
-               "version": "0.1.5",
-               "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.5.tgz",
-               "integrity": "sha512-HvofNU4QCvfUCWnocQP1IAWaqop5wpWrB0mKB6SSh0fcpV0PdmQNS6tdUuFew1utpYlUvYYzz84oDkrD76GB9A==",
+               "version": "0.1.12",
+               "resolved": "https://registry.npmjs.org/markdownlint-micromark/-/markdownlint-micromark-0.1.12.tgz",
+               "integrity": "sha512-RlB6EwMGgc0sxcIhOQ2+aq7Zw1V2fBnzbXKGgYK/mVWdT7cz34fteKSwfYeo4rL6+L/q2tyC9QtD/PgZbkdyJQ==",
+               "dev": true
+            },
+            "mdurl": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+               "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+               "dev": true
+            },
+            "uc.micro": {
+               "version": "2.1.0",
+               "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+               "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
                "dev": true
             }
          }
@@ -10869,6 +10987,12 @@
          "version": "2.1.1",
          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+         "dev": true
+      },
+      "punycode.js": {
+         "version": "2.3.1",
+         "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+         "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
          "dev": true
       },
       "q": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
       "@silvermine/eslint-config": "3.1.0-beta.0",
       "@silvermine/standardization": "2.2.3",
       "chai": "4.3.7",
-      "markdownlint": "0.29.0",
+      "markdownlint": "0.36.1",
       "mocha": "10.2.0"
    },
    "dependencies": {

--- a/tests/indent-alignment.test.js
+++ b/tests/indent-alignment.test.js
@@ -1069,6 +1069,13 @@ describe('Indent Alignment', () => {
          '   Lorem ipsum dolor sit amet',
          '</div>',
       ]);
+
+      await testValidExample([
+         '<a',
+         'href="#">',
+         '   link text',
+         '</a>',
+      ]);
    });
 
    it('reports errors for incorrect indention of item under long ol list item prefixes', async () => {


### PR DESCRIPTION
In `markdownlint` `0.36.0`, the support for `micromark` returned. Adding it in the config object fixes the error described in [this issue](https://github.com/silvermine/markdownlint-rule-indent-alignment/issues/7)

The new `micromark` version changes some previously assumed parser behaviors. It causes some errors related to nested intentation in HTML snippets. Since currently there is no need to lint HTML, the tokens related to it are now ignored.

Introduces a new test verification to prevent an error where `htmlText` tokens cause other text tokens to appear to be indented.